### PR TITLE
Selecionar > Marcar

### DIFF
--- a/language/pt-br/viewforum.php
+++ b/language/pt-br/viewforum.php
@@ -47,21 +47,21 @@ $lang = array_merge($lang, array(
 
 	'LOGIN_NOTIFY_FORUM'	=> 'Você foi notificado sobre este fórum. Por favor, faça o login para visualizá-lo.',
 
-	'MARK_TOPICS_READ'		=> 'Selecionar todos os tópicos como lidos',
+	'MARK_TOPICS_READ'		=> 'Marcar todos os tópicos como lidos',
 
 	'NEW_POSTS_HOT'			=> 'Mensagens novas [ Popular ]',	// Not used anymore
 	'NEW_POSTS_LOCKED'		=> 'Mensagens novas [ Trancadas ]',	// Not used anymore
 	'NO_NEW_POSTS_HOT'		=> 'Não há mensagens novas [ Popular ]',	// Not used anymore
 	'NO_NEW_POSTS_LOCKED'	=> 'Não há mensagens novas [ Trancadas ]',	// Not used anymore
 	'NO_READ_ACCESS'		=> 'Você não possui as permissões requeridas para ler tópicos neste fórum.',
-	'NO_UNREAD_POSTS_HOT'	=> 'Nenhuma mensagem não lida [ Popular ]',
+	'NO_UNREAD_POSTS_HOT'	=> 'Nenhuma mensagem não lida [ Populares ]',
 	'NO_UNREAD_POSTS_LOCKED'	=> 'Nenhuma mensagem não lida [ Trancadas ]',
 
 	'POST_FORUM_LOCKED'		=> 'Este fórum está trancado',
 
-	'TOPICS_MARKED'			=> 'Todos os tópicos foram selecionados como lidos',
+	'TOPICS_MARKED'			=> 'Todos os tópicos foram marcados como lidos',
 
-	'UNREAD_POSTS_HOT'		=> 'Mensagens não lidas [ Popular ]',
+	'UNREAD_POSTS_HOT'		=> 'Mensagens não lidas [ Populares ]',
 	'UNREAD_POSTS_LOCKED'	=> 'Mensagens não lidas [ Trancadas ]',
 
 	'VIEW_FORUM'			=> 'Exibir fórum',


### PR DESCRIPTION
Creio que neste contexto o termo correto seria "marcar / marcado" e não
"selecionar / selecionado". Enviando para avaliação da equipe...
